### PR TITLE
Move gameday close and lock to a new task that runs at 4:30.

### DIFF
--- a/src/common/models/Task.ts
+++ b/src/common/models/Task.ts
@@ -12,6 +12,12 @@ export default abstract class Task {
     this.interval = interval;
   }
 
+  private async run(): Promise<void> {
+    Stumper.info(`Running task: ${this.name}`, "common:Task:run");
+    await this.execute();
+    Stumper.info(`Task ${this.name} completed!`, "common:Task:run");
+  }
+
   protected abstract execute(): Promise<void>;
 
   getName(): string {
@@ -24,7 +30,7 @@ export default abstract class Task {
 
   createScheduledJob(): void {
     Stumper.debug(`Creating scheduled job: ${this.name}`, "common:Task:createScheduledJob");
-    this.job = schedule.scheduleJob(this.interval, this.execute);
+    this.job = schedule.scheduleJob(this.interval, this.run);
   }
 
   stopScheduledJob(): void {

--- a/src/modules/gamedayPosts/GameDayPostsModule.ts
+++ b/src/modules/gamedayPosts/GameDayPostsModule.ts
@@ -1,5 +1,6 @@
 import Module from "../../common/models/Module";
 import SlashCommand from "../../common/models/SlashCommand";
+import CloseAndLockPostsTask from "./tasks/CloseAndLockPostsTask";
 import CreateGameDayPostTask from "./tasks/CreateGameDayPostTask";
 
 export default class GameDayPostsModule extends Module {
@@ -14,7 +15,10 @@ export default class GameDayPostsModule extends Module {
   }
 
   private registerSchedules(): void {
-    // Run every day at midnight
+    // Run every day at 12:30 AM
     new CreateGameDayPostTask().createScheduledJob();
+
+    // Run every day at 4:30 AM
+    new CloseAndLockPostsTask().createScheduledJob();
   }
 }

--- a/src/modules/gamedayPosts/tasks/CloseAndLockPostsTask.ts
+++ b/src/modules/gamedayPosts/tasks/CloseAndLockPostsTask.ts
@@ -1,0 +1,13 @@
+import Task from "../../../common/models/Task";
+import { closeAndLockOldPosts } from "../utils/GameChecker";
+
+export default class CloseAndLockPostsTask extends Task {
+  constructor() {
+    // Run every day at 4:30 AM
+    super("CloseAndLockPostsTask", "0 30 4 * * *");
+  }
+
+  protected async execute(): Promise<void> {
+    await closeAndLockOldPosts();
+  }
+}

--- a/src/modules/gamedayPosts/tasks/CreateGameDayPostTask.ts
+++ b/src/modules/gamedayPosts/tasks/CreateGameDayPostTask.ts
@@ -1,5 +1,5 @@
 import Task from "../../../common/models/Task";
-import { checkForGameDay, closeAndLockOldPosts } from "../utils/GameChecker";
+import { checkForGameDay } from "../utils/GameChecker";
 
 export default class CreateGameDayPostTask extends Task {
   constructor() {
@@ -8,7 +8,6 @@ export default class CreateGameDayPostTask extends Task {
   }
 
   protected async execute(): Promise<void> {
-    await closeAndLockOldPosts();
     await checkForGameDay();
   }
 }


### PR DESCRIPTION
This is to prevent issues where games that start at 10:00 arent over at 12:30