### PR TITLE
Change captcha wrong timeout to actually use discords timeout

### DIFF
--- a/drizzle/migrations/0012_curly_lenny_balinger.sql
+++ b/drizzle/migrations/0012_curly_lenny_balinger.sql
@@ -1,0 +1,2 @@
+DROP INDEX "joinleave_timedout_at_idx";--> statement-breakpoint
+ALTER TABLE "joinleave__not_verified_users" DROP COLUMN "timedout_at";

--- a/drizzle/migrations/meta/0012_snapshot.json
+++ b/drizzle/migrations/meta/0012_snapshot.json
@@ -1,0 +1,1063 @@
+{
+  "id": "b6b834e6-7c79-4fa4-87c1-40b3adbc15ef",
+  "prevId": "d9eb26d5-6ee7-4ee4-a562-012e624e2e56",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.common__audit_log": {
+      "name": "common__audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "module_name": {
+          "name": "module_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "common__audit_log_severity_type",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INFO'"
+        }
+      },
+      "indexes": {
+        "audit_log_module_name_idx": {
+          "name": "audit_log_module_name_idx",
+          "columns": [
+            {
+              "expression": "module_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_timestamp_idx": {
+          "name": "audit_log_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_user_id_idx": {
+          "name": "audit_log_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_module_timestamp_idx": {
+          "name": "audit_log_module_timestamp_idx",
+          "columns": [
+            {
+              "expression": "module_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.common__config": {
+      "name": "common__config",
+      "schema": "",
+      "columns": {
+        "module_name": {
+          "name": "module_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "common__config_module_name_key_pk": {
+          "name": "common__config_module_name_key_pk",
+          "columns": ["module_name", "key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bluesky__state": {
+      "name": "bluesky__state",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customcommands__commands": {
+      "name": "customcommands__commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "customcommands__commands_name_unique": {
+          "name": "customcommands__commands_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customcommands__state": {
+      "name": "customcommands__state",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_ids": {
+          "name": "message_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daysuntil__dates": {
+      "name": "daysuntil__dates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "daysuntil_enabled_idx": {
+          "name": "daysuntil_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daysuntil__dates_name_unique": {
+          "name": "daysuntil__dates_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.joinleave__state": {
+      "name": "joinleave__state",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "boolean_value": {
+          "name": "boolean_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.joinleave__left_users": {
+      "name": "joinleave__left_users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "roles": {
+          "name": "roles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.joinleave__not_verified_users": {
+      "name": "joinleave__not_verified_users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "questions_answered": {
+          "name": "questions_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lock": {
+          "name": "lock",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "incorrect_answers": {
+          "name": "incorrect_answers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "time_out_count": {
+          "name": "time_out_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_to_thread": {
+          "name": "added_to_thread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "joinleave_added_at_idx": {
+          "name": "joinleave_added_at_idx",
+          "columns": [
+            {
+              "expression": "added_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.levels__levels": {
+      "name": "levels__levels",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_experience": {
+          "name": "total_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "time_of_last_message": {
+          "name": "time_of_last_message",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "levels_total_experience_idx": {
+          "name": "levels_total_experience_idx",
+          "columns": [
+            {
+              "expression": "total_experience",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "levels_current_level_idx": {
+          "name": "levels_current_level_idx",
+          "columns": [
+            {
+              "expression": "current_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.levels__levels_experience": {
+      "name": "levels__levels_experience",
+      "schema": "",
+      "columns": {
+        "level_number": {
+          "name": "level_number",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "experience": {
+          "name": "experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nhl__posts": {
+      "name": "nhl__posts",
+      "schema": "",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nhl_channel_id_idx": {
+          "name": "nhl_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nhl__live_data": {
+      "name": "nhl__live_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_start_time": {
+          "name": "game_start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period": {
+          "name": "current_period",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pins__pins": {
+      "name": "pins__pins",
+      "schema": "",
+      "columns": {
+        "og_message_id": {
+          "name": "og_message_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "og_created_at": {
+          "name": "og_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "og_channel_id": {
+          "name": "og_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_by": {
+          "name": "pinned_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pins_og_channel_id_idx": {
+          "name": "pins_og_channel_id_idx",
+          "columns": [
+            {
+              "expression": "og_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pins_pinned_at_idx": {
+          "name": "pins_pinned_at_idx",
+          "columns": [
+            {
+              "expression": "pinned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pins_pinned_by_idx": {
+          "name": "pins_pinned_by_idx",
+          "columns": [
+            {
+              "expression": "pinned_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playeremojis__emojis": {
+      "name": "playeremojis__emojis",
+      "schema": "",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "emoji_id": {
+          "name": "emoji_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactionrole__messages": {
+      "name": "reactionrole__messages",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "reactionrole_message_id_idx": {
+          "name": "reactionrole_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rules__messages": {
+      "name": "rules__messages",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rules__section_messages": {
+      "name": "rules__section_messages",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "rules__section_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rules__section_messages_message_id_rules__messages_message_id_fk": {
+          "name": "rules__section_messages_message_id_rules__messages_message_id_fk",
+          "tableFrom": "rules__section_messages",
+          "tableTo": "rules__messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["message_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rules__section_messages_section_id_rules__sections_name_fk": {
+          "name": "rules__section_messages_section_id_rules__sections_name_fk",
+          "tableFrom": "rules__section_messages",
+          "tableTo": "rules__sections",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["name"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "type_constraint": {
+          "name": "type_constraint",
+          "value": "(\"rules__section_messages\".\"type\" = 'HEADER'::rules__section_type AND \"rules__section_messages\".\"url\" IS NOT NULL AND \"rules__section_messages\".\"content\" IS NULL) OR (\"rules__section_messages\".\"type\" = 'CONTENT'::rules__section_type AND \"rules__section_messages\".\"content\" IS NOT NULL AND \"rules__section_messages\".\"url\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.rules__sections": {
+      "name": "rules__sections",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "friendly_name": {
+          "name": "friendly_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rules__state": {
+      "name": "rules__state",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.visitorrole__state": {
+      "name": "visitorrole__state",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.common__audit_log_severity_type": {
+      "name": "common__audit_log_severity_type",
+      "schema": "public",
+      "values": ["INFO", "WARNING", "CRITICAL", "ERROR"]
+    },
+    "public.rules__section_type": {
+      "name": "rules__section_type",
+      "schema": "public",
+      "values": ["HEADER", "CONTENT"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1776667729313,
       "tag": "0011_futuristic_hydra",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1778455403250,
+      "tag": "0012_curly_lenny_balinger",
+      "breakpoints": true
     }
   ]
 }

--- a/src/modules/joinLeave/db/JoinLeaveDB.ts
+++ b/src/modules/joinLeave/db/JoinLeaveDB.ts
@@ -71,22 +71,6 @@ export default class JoinLeaveDB extends ModuleDatabase {
     return result?.incorrect ?? 0;
   }
 
-  async startTimeout(userId: string): Promise<void> {
-    await this.db.update(notVerifiedUsers).set({ timedoutAt: new Date() }).where(eq(notVerifiedUsers.userId, userId));
-  }
-
-  async removeTimeout(userId: string): Promise<void> {
-    await this.db.update(notVerifiedUsers).set({ timedoutAt: null }).where(eq(notVerifiedUsers.userId, userId));
-  }
-
-  async getTimeout(userId: string): Promise<Date | undefined> {
-    const result = await this.getSingleRowWithFields(notVerifiedUsers, eq(notVerifiedUsers.userId, userId), {
-      timeout: notVerifiedUsers.timedoutAt,
-    });
-
-    return result?.timeout ?? undefined;
-  }
-
   async getTimeOutCount(userId: string): Promise<number> {
     const result = await this.getSingleRowWithFields(notVerifiedUsers, eq(notVerifiedUsers.userId, userId), {
       count: notVerifiedUsers.timeOutCount,

--- a/src/modules/joinLeave/db/schema.ts
+++ b/src/modules/joinLeave/db/schema.ts
@@ -9,12 +9,11 @@ export const notVerifiedUsers = createModuleTable(
     questionsAnswered: integer("questions_answered").default(0).notNull(),
     lock: boolean("lock").default(false).notNull(),
     incorrectAnswers: integer("incorrect_answers").default(0).notNull(),
-    timedoutAt: timestamp("timedout_at"),
     timeOutCount: integer("time_out_count").default(0).notNull(),
     threadId: text("thread_id"),
     addedToThread: boolean("added_to_thread").default(false).notNull(),
   },
-  (table) => [index("joinleave_added_at_idx").on(table.addedAt), index("joinleave_timedout_at_idx").on(table.timedoutAt)],
+  (table) => [index("joinleave_added_at_idx").on(table.addedAt)],
 );
 
 export const leftUsers = createModuleTable("joinleave__left_users", {

--- a/src/modules/joinLeave/listeners/onMessageCreate.ts
+++ b/src/modules/joinLeave/listeners/onMessageCreate.ts
@@ -209,14 +209,22 @@ export default (): void => {
                 maxTimeOuts,
               },
             });
-            await member.timeout(timeoutLength * 1000, "Too many incorrect captcha answers");
+            if (member.moderatable) {
+              await member.timeout(timeoutLength * 1000, "Too many incorrect captcha answers");
+            } else {
+              Stumper.warning(`User ${user.id} is not moderatable, skipping timeout...`, "joinLeave:onMessageCreate:onMessageCreate");
+            }
             await db.incrementTimeOutCount(user.id);
             await db.resetIncorrectAnswers(user.id);
             await message.reply(`Wrong! You have reached the maximum number of incorrect answers! Try again in ${timeoutHours.toFixed(1)} hours.`);
           }
         } else {
           // Incorrect answer, but the user has not reached the maximum number of wrong answers
-          await member.timeout(2 * 1000, "Incorrect captcha answer");
+          if (member.moderatable) {
+            await member.timeout(2 * 1000, "Incorrect captcha answer");
+          } else {
+            Stumper.warning(`User ${user.id} is not moderatable, skipping timeout...`, "joinLeave:onMessageCreate:onMessageCreate");
+          }
           await message.reply("Incorrect! Try again.");
         }
       }

--- a/src/modules/joinLeave/listeners/onMessageCreate.ts
+++ b/src/modules/joinLeave/listeners/onMessageCreate.ts
@@ -5,7 +5,6 @@ import ConfigManager from "@common/managers/ConfigManager";
 import discord from "@common/utils/discord/discord";
 import { sendCaptcha } from "../utils/Captcha";
 import Stumper from "stumper";
-import Time from "@common/utils/Time";
 import { AuditLogSeverity } from "@common/db/schema";
 import JoinImageGenerator from "../utils/JoinImageGenerator";
 
@@ -56,39 +55,6 @@ export default (): void => {
       const questions = ConfigManager.getInstance().getConfig("JoinLeave").captchaQuestions;
       if (questions.length <= notVerifiedUser.questionsAnswered) {
         return;
-      }
-
-      const currentTimeout = await db.getTimeout(user.id);
-      const timeoutCooldown = ConfigManager.getInstance().getConfig("JoinLeave").incorrectAnswersTimeout;
-      if (currentTimeout) {
-        const timeSinceTimeoutMilli = Time.timeSince(currentTimeout.getTime());
-        const timeUntilTimeoutSec = Math.floor(timeSinceTimeoutMilli / 1000);
-        if (timeUntilTimeoutSec < timeoutCooldown) {
-          void db.createAuditLog({
-            action: "messageSentWhileTimedOut",
-            userId: user.id,
-            severity: AuditLogSeverity.WARNING,
-            details: {
-              messageId: message.id,
-              content: message.content,
-              timeUntilTimeoutSec,
-            },
-          });
-          Stumper.warning(
-            `User ${user.id} has to wait ${timeoutCooldown - timeUntilTimeoutSec} seconds before answering again`,
-            "joinLeave:onMessageCreate:onMessageCreate",
-          );
-          await message.reply(`You have to wait ${timeoutCooldown - timeUntilTimeoutSec} seconds before answering again.`);
-          return;
-        } else {
-          await db.createAuditLog({
-            action: "timeOutRemoved",
-            userId: user.id,
-            severity: AuditLogSeverity.INFO,
-          });
-          await db.removeTimeout(user.id);
-          await db.resetIncorrectAnswers(user.id);
-        }
       }
 
       const content = message.content.toLowerCase();
@@ -243,9 +209,10 @@ export default (): void => {
                 maxTimeOuts,
               },
             });
-            await db.startTimeout(user.id);
+            await member.timeout(timeoutLength * 1000, "Too many incorrect captcha answers");
             await db.incrementTimeOutCount(user.id);
-            await message.reply(`Wrong! You have reached the maximum number of incorrect answers! Try again in ${timeoutHours} hours.`);
+            await db.resetIncorrectAnswers(user.id);
+            await message.reply(`Wrong! You have reached the maximum number of incorrect answers! Try again in ${timeoutHours.toFixed(1)} hours.`);
           }
         } else {
           // Incorrect answer, but the user has not reached the maximum number of wrong answers

--- a/src/modules/joinLeave/listeners/onMessageCreate.ts
+++ b/src/modules/joinLeave/listeners/onMessageCreate.ts
@@ -216,6 +216,7 @@ export default (): void => {
           }
         } else {
           // Incorrect answer, but the user has not reached the maximum number of wrong answers
+          await member.timeout(2 * 1000, "Incorrect captcha answer");
           await message.reply("Incorrect! Try again.");
         }
       }


### PR DESCRIPTION
Fixes #247 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced join-leave verification timeout system by leveraging Discord's native timeout mechanism for faster, more immediate, and more reliable enforcement of verification rules.
  * Updated timeout enforcement to immediately respond to rule violations with direct Discord timeouts rather than relying on delayed processing.
  * Simplified internal timeout tracking mechanisms for improved performance and maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Flyerscord/Flyerscord-Bot/pull/249)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->